### PR TITLE
修改了Header包头接受但是因为网络问题导致丢包，包数据不完全的情况，以及客户端进程数减少线程数的使用符合大多数录友配置

### DIFF
--- a/example/caller/Kclient.cc
+++ b/example/caller/Kclient.cc
@@ -47,8 +47,8 @@ int main(int argc, char **argv) {
     // 创建日志对象
     KrpcLogger logger("MyRPC");
 
-    const int thread_count =5000;       // 并发线程数
-    const int requests_per_thread = 1000; // 每个线程发送的请求数
+const int thread_count = 100;      // 线程数改为 100
+const int requests_per_thread = 5000; // 每个线程发 5000 次请求
 
     std::vector<std::thread> threads;  // 存储线程对象的容器
     std::atomic<int> success_count(0); // 成功请求的计数器

--- a/src/include/Krpcchannel.h
+++ b/src/include/Krpcchannel.h
@@ -10,7 +10,9 @@ public:
     KrpcChannel(bool connectNow);
     virtual ~KrpcChannel()
     {
-        
+          if (m_clientfd >= 0) {
+        close(m_clientfd);
+    }  
     }
     void CallMethod(const ::google::protobuf::MethodDescriptor *method,
                     ::google::protobuf::RpcController *controller,
@@ -26,5 +28,7 @@ private:
     int m_idx; // 用来划分服务器ip和port的下标
     bool newConnect(const char *ip, uint16_t port);
     std::string QueryServiceHost(ZkClient *zkclient, std::string service_name, std::string method_name, int &idx);
+       // 新增：确保读取指定长度的数据，解决TCP拆包
+    ssize_t recv_exact(int fd, char* buf, size_t size);
 };
 #endif


### PR DESCRIPTION
根据群友的反馈修改代码文件修改有Kclient修改并发数，Channel修改发送固定4+头字节+参数数据传输数据，Provider文件读取采用peek获取整个包的数据如果缓冲区剩余数据 小于 4字节长度头 + 内容长度，说明包没收全，退出等待下一次。